### PR TITLE
glowcoal -> glowcoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 pack/overrides/config/fancymenu/*
+
+# IDE
+
+.idea

--- a/pack/overrides/global_resource_packs/permafrost-lore/assets/infernalexpansion/lang/en_us.json
+++ b/pack/overrides/global_resource_packs/permafrost-lore/assets/infernalexpansion/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+    "item.infernalexp.glowcoal": "Glowcoke"
+}


### PR DESCRIPTION
The glowcoke quest uses Glowcoal, but calls it Glowcoke: https://github.com/Wizelf402/Permafrost/blob/de268c9e84d2bdeead7f0c729fdcc1e8e7e3feaf/pack/overrides/config/hqm/default/sets/Reclaiming_the_World.json#L477